### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
#5 Add Dependabot

Added dependabot as a workflow. Tested and passed on forked repo. 

Note: must enable dependabot in security repo's security tab:

1. Trigger a Manual Update (GitHub UI):
    - Go to your repository’s Code tab.
    - In the Security tab, you should see a section for Dependabot.
    - If available, look for an option to Check for updates. This can help trigger Dependabot manually if it hasn't run yet.
 
2. Check GitHub Repository Settings:
     - Make sure Dependabot is not disabled at the organization or repository level:
          - Go to Settings of the repository.
          - Under Security & analysis, make sure that Dependency graph and Dependabot alerts are enabled.
          - Also, ensure Dependabot security updates are enabled.